### PR TITLE
Update RxAlamofire to user latest version of RxSwift (version 2.0)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,10 +4,9 @@ platform :ios, '8.0'
 use_frameworks!
 
 pod 'Alamofire', '~> 3.0'
-pod 'RxSwift', '~> 2.0.0-beta'
-pod 'RxCocoa', '~> 2.0.0-beta'
-pod 'RxBlocking', '~> 2.0.0-beta'
-
+pod 'RxSwift', '~> 2.0'
+pod 'RxCocoa', '~> 2.0'
+pod 'RxBlocking', '~> 2.0'
 
 target 'RxAlamofireTests' do
   pod 'Quick'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,42 +1,42 @@
 PODS:
-  - Alamofire (3.1.2)
+  - Alamofire (3.1.4)
   - Nimble (3.0.0)
-  - OHHTTPStubs (4.6.0):
-    - OHHTTPStubs/Default (= 4.6.0)
-  - OHHTTPStubs/Core (4.6.0)
-  - OHHTTPStubs/Default (4.6.0):
+  - OHHTTPStubs (4.7.0):
+    - OHHTTPStubs/Default (= 4.7.0)
+  - OHHTTPStubs/Core (4.7.0)
+  - OHHTTPStubs/Default (4.7.0):
     - OHHTTPStubs/Core
     - OHHTTPStubs/JSON
     - OHHTTPStubs/NSURLSession
     - OHHTTPStubs/OHPathHelpers
-  - OHHTTPStubs/JSON (4.6.0):
+  - OHHTTPStubs/JSON (4.7.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/NSURLSession (4.6.0):
+  - OHHTTPStubs/NSURLSession (4.7.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/OHPathHelpers (4.6.0)
+  - OHHTTPStubs/OHPathHelpers (4.7.0)
   - Quick (0.8.0)
-  - RxBlocking (2.0.0-beta.3):
-    - RxSwift (~> 2.0.0-beta)
-  - RxCocoa (2.0.0-beta.3):
-    - RxSwift (~> 2.0.0-beta)
-  - RxSwift (2.0.0-beta.3)
+  - RxBlocking (2.0.0):
+    - RxSwift (~> 2.0)
+  - RxCocoa (2.0.0):
+    - RxSwift (~> 2.0)
+  - RxSwift (2.0.0)
 
 DEPENDENCIES:
   - Alamofire (~> 3.0)
   - Nimble
   - OHHTTPStubs
   - Quick
-  - RxBlocking (~> 2.0.0-beta)
-  - RxCocoa (~> 2.0.0-beta)
-  - RxSwift (~> 2.0.0-beta)
+  - RxBlocking (~> 2.0)
+  - RxCocoa (~> 2.0)
+  - RxSwift (~> 2.0)
 
 SPEC CHECKSUMS:
-  Alamofire: 7c16ca65f3c7e681fd925fd7f2dec7747ff96855
+  Alamofire: fbc829692f351fa1d8a31dd75fd7f7f56fea31fb
   Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
-  OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
+  OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  RxBlocking: 331f8bdedf77198f8ff1a37f09c492f1f4f631e5
-  RxCocoa: 1472006304b296d03c847f78b21384523cc4902e
-  RxSwift: 19fbe885b404d1d36d42ac8535134739a9b42952
+  RxBlocking: a95a10ed54eb5d116f6c9a87047ff671e181d07b
+  RxCocoa: b0ebd70b4f7450bdb3c8987b122f8fd568dc1e2f
+  RxSwift: d83246efa6f16c50c143bec134649d045498f601
 
 COCOAPODS: 0.39.0

--- a/RxAlamofire/MasterViewController.swift
+++ b/RxAlamofire/MasterViewController.swift
@@ -47,7 +47,7 @@ class MasterViewController: UIViewController, UITextFieldDelegate {
         if let fromValue = NSNumberFormatter().numberFromString(self.fromTextField.text!) {
 
             RxAlamofire.requestJSON(Method.GET, sourceStringURL)
-                .observeOn(MainScheduler.sharedInstance)
+                .observeOn(MainScheduler.instance)
                 .debug()
                 .subscribe(onNext: { (r, json) -> Void in
                         if let dict = json as? [String: AnyObject] {
@@ -76,18 +76,18 @@ func exampleUsages() {
     
     _ = session
         .rx_JSON(.GET, stringURL)
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     _ = session
         .rx_data(.GET, stringURL)
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // MARK: With Alamofire engine
     
     _ = JSON(.GET, stringURL)
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     _ = request(.GET, stringURL)
@@ -97,7 +97,7 @@ func exampleUsages() {
                 .validate(contentType: ["text/json"])
                 .rx_JSON()
         }
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // progress
@@ -108,7 +108,7 @@ func exampleUsages() {
                 .validate(contentType: ["text/json"])
                 .rx_progress()
         }
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // just fire upload and display progress
@@ -119,7 +119,7 @@ func exampleUsages() {
                 .validate(contentType: ["text/json"])
                 .rx_progress()
         }
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // progress and final result
@@ -136,9 +136,9 @@ func exampleUsages() {
                 .map { d -> NSData? in d }
                 .startWith(nil as NSData?)
             let progressPart = validatedRequest.rx_progress()
-            return combineLatest(dataPart, progressPart) { ($0, $1) }
+            return Observable.combineLatest(dataPart, progressPart) { ($0, $1) }
         }
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     
@@ -149,18 +149,18 @@ func exampleUsages() {
     
     // simple case
     _ = manager.rx_JSON(.GET, stringURL)
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     
     // NSURLHTTPResponse + JSON
     _ = manager.rx_responseJSON(.GET, stringURL)
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // NSURLHTTPResponse + String
     _ = manager.rx_responseString(.GET, stringURL)
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // NSURLHTTPResponse + Validation + String
@@ -171,7 +171,7 @@ func exampleUsages() {
                 .validate(contentType: ["text/json"])
                 .rx_string()
         }
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // NSURLHTTPResponse + Validation + NSURLHTTPResponse + String
@@ -182,7 +182,7 @@ func exampleUsages() {
                 .validate(contentType: ["text/json"])
                 .rx_responseString()
         }
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // NSURLHTTPResponse + Validation + NSURLHTTPResponse + String + Progress
@@ -197,9 +197,9 @@ func exampleUsages() {
                 .map { d -> String? in d }
                 .startWith(nil as String?)
             let progressPart = validatedRequest.rx_progress()
-            return combineLatest(stringPart, progressPart) { ($0, $1) }
+            return Observable.combineLatest(stringPart, progressPart) { ($0, $1) }
         }
-        .observeOn(MainScheduler.sharedInstance)
+        .observeOn(MainScheduler.instance)
         .subscribe { print($0) }
     
     // MARK: wrapping of some request that isn't explicitly wrapped
@@ -219,10 +219,10 @@ func exampleUsages() {
         let postObservable = JSON(Method.GET, dummyPostURLString)
         let commentsObservable = JSON(Method.GET, dummyCommentsURLString)
         self.dummyDataTextView.text = "Loading..."
-        zip(postObservable, commentsObservable) { postJSON, commentsJSON in
+        Observable.zip(postObservable, commentsObservable) { postJSON, commentsJSON in
                 return (postJSON, commentsJSON)
             }
-            .observeOn(MainScheduler.sharedInstance)
+            .observeOn(MainScheduler.instance)
             .subscribe(onNext: { postJSON, commentsJSON in
                 
                 let postInfo = NSMutableString()

--- a/RxAlamofire/Source/Cocoa/NSURLSession+RxAlamofire.swift
+++ b/RxAlamofire/Source/Cocoa/NSURLSession+RxAlamofire.swift
@@ -31,15 +31,16 @@ extension NSURLSession {
         _ URLString: URLStringConvertible,
         parameters: [String: AnyObject]? = nil,
         encoding: ParameterEncoding = .URL,
-        headers: [String: String]? = nil) -> Observable<AnyObject!> {
+        headers: [String: String]? = nil) -> Observable<AnyObject> {
             do {
-                return rx_JSON(try URLRequest(method, URLString, parameters: parameters, encoding: encoding, headers: headers))
+                let request = try URLRequest(method, URLString, parameters: parameters, encoding: encoding, headers: headers) as NSURLRequest
+                return rx_JSON(request)
             }
             catch let error {
-                return failWith(error)
+                return Observable.error(error)
             }
     }
-    
+
     /**
      Creates an observable returning a tuple of `(NSData!, NSURLResponse)`.
      
@@ -51,22 +52,20 @@ extension NSURLSession {
      
      - returns: An observable of a tuple containing data and the request
      */
-    
-    /*
     public func rx_response(method: Alamofire.Method,
         _ URLString: URLStringConvertible,
         parameters: [String: AnyObject]? = nil,
         encoding: ParameterEncoding = .URL,
-        headers: [String: String]? = nil) -> Observable<(NSData!, NSURLResponse)> {
+        headers: [String: String]? = nil) -> Observable<(NSData, NSHTTPURLResponse)> {
             do {
                 let request = try URLRequest(method, URLString, parameters: parameters, encoding: encoding, headers: headers) as NSURLRequest
-                return rx_response(request: request)
+                return rx_response(request)
             }
             catch let error {
-                return failWith(error)
+                return Observable.error(error)
             }
-    }*/
-    
+    }
+
     /**
      Creates an observable of response's content as `NSData`.
      
@@ -87,7 +86,7 @@ extension NSURLSession {
                 return rx_data(try URLRequest(method, URLString, parameters: parameters, encoding: encoding, headers: headers))
             }
             catch let error {
-                return failWith(error)
+                return Observable.error(error)
             }
     }
 }

--- a/RxAlamofire/Source/RxAlamofire.swift
+++ b/RxAlamofire/Source/RxAlamofire.swift
@@ -336,7 +336,7 @@ extension Manager {
     - returns: A generic observable of created request
     */
     public func rx_request(createRequest: (Manager) throws -> Request) -> Observable<Request> {
-        return create { observer -> Disposable in
+        return Observable.create { observer -> Disposable in
             let request: Request
             do {
                 request = try createRequest(self)
@@ -674,7 +674,7 @@ extension Request {
         responseSerializer: T)
         -> Observable<(NSHTTPURLResponse, T.SerializedObject)>
     {
-        return create { observer in
+        return Observable.create { observer in
             self.response(queue: queue, responseSerializer: responseSerializer) { (packedResponse) -> Void in
                 switch packedResponse.result {
                 case .Success(let result):
@@ -705,7 +705,7 @@ extension Request {
         responseSerializer: T)
         -> Observable<T.SerializedObject>
     {
-        return create { observer in
+        return Observable.create { observer in
             self
                 .rx_validateSuccessfulResponse()
                 .response(queue: queue, responseSerializer: responseSerializer) { (packedResponse) -> Void in
@@ -807,7 +807,7 @@ extension Request {
     - returns: An instance of `Observable<(Int64, Int64, Int64)>`
     */
     public func rx_progress() -> Observable<RxProgress> {
-        return create { observer in
+        return Observable.create { observer in
             self.progress() { bytesWritten, totalBytesWritten, totalBytesExpectedToWrite in
                 observer.onNext(RxProgress(bytesWritten: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite))
             }


### PR DESCRIPTION
Hello @bontoJR,

I have update RxAlamofire to use the latest version of RxSwift.

Summary of my actions:

- Bumped version of RxSwift in Podfile.
- Update pods.
- Fix all error messages regarding RxSwift syntax.
- Fix NSURLSession+RxAlamofire rx_json and rx_request extension methods.
	- one of the problems was with return types
	`Observable<AnyObject!>` changed to `<Observable<AnyObject>`
	- other was with method `rx_JSON` from `RxCocoa` expecting `NSURLRequest` but method `URLRequest` return type was `NSMutableURLRequest`
	
Please review my changes when you get a chance, and especially the last fix, as I'm not 100% if this is desired behaviour.

Let me know if there is anything else I can help with. Have a nice day :)
