### PR TITLE
Update Carthage Dependency Versions

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "ReactiveX/RxSwift" ~> 2.0 
-github "Alamofire/Alamofire" ~> 3.0
+github "ReactiveX/RxSwift" ~> 2.1 
+github "Alamofire/Alamofire" ~> 3.1
 


### PR DESCRIPTION
Carthage dependencies references versions earlier than those in cocoa pods. In the case of Alamofire Carthage required version 3.0, while Cocoapods required 3.1, this resulted in build failures.

This build brings carthage dependencies inline with those in cocoapods. RxSwift 2.1 & Alamofire 3.1