### PR TITLE
Fix *rx_progress()* to send *onCompleted()* when *totalBytesWritten* is equal to *totalBytesExpectedToWrite*

### DIFF
--- a/RxAlamofire/Source/RxAlamofire.swift
+++ b/RxAlamofire/Source/RxAlamofire.swift
@@ -809,13 +809,19 @@ extension Request {
     public func rx_progress() -> Observable<RxProgress> {
         return Observable.create { observer in
             self.progress() { bytesWritten, totalBytesWritten, totalBytesExpectedToWrite in
+                
                 observer.onNext(RxProgress(bytesWritten: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite))
+                
+                if totalBytesWritten == totalBytesExpectedToWrite {
+                    observer.onCompleted()
+                }
+
             }
             
             return NopDisposable.instance
         }
-            // warm up a bit :)
-            .startWith(RxProgress(bytesWritten: 0, totalBytesWritten: 0, totalBytesExpectedToWrite: 0))
+        // warm up a bit :)
+        .startWith(RxProgress(bytesWritten: 0, totalBytesWritten: 0, totalBytesExpectedToWrite: 0))
     }
 }
 

--- a/RxAlamofire/Source/RxAlamofire.swift
+++ b/RxAlamofire/Source/RxAlamofire.swift
@@ -812,7 +812,7 @@ extension Request {
                 
                 observer.onNext(RxProgress(bytesWritten: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite))
                 
-                if totalBytesWritten == totalBytesExpectedToWrite {
+                if totalBytesWritten >= totalBytesExpectedToWrite {
                     observer.onCompleted()
                 }
 


### PR DESCRIPTION
Hello @bontoJR ,

I have made some changes to rx_progress() to allow signal completion when totalBytesWritten is equal to totalBytesExpectedToWrite, let me know what do you think.

Have a nice day

Ivan