### PR TITLE
[WIP] Removing embedded framework

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" "3.1.5"
-github "ReactiveX/RxSwift" "2.1.0"
+github "Alamofire/Alamofire" "3.3.1"
+github "ReactiveX/RxSwift" "2.4"

--- a/RxAlamofire.xcodeproj/project.pbxproj
+++ b/RxAlamofire.xcodeproj/project.pbxproj
@@ -402,7 +402,6 @@
 				181B4FF31C4D74A8000BA6D6 /* Frameworks */,
 				181B4FF41C4D74A8000BA6D6 /* Headers */,
 				181B4FF51C4D74A8000BA6D6 /* Resources */,
-				181B50011C4D74FC000BA6D6 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -638,22 +637,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxAlamofireExample-RxAlamofireTests/Pods-RxAlamofireExample-RxAlamofireTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		181B50011C4D74FC000BA6D6 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/RxSwift.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/RxCocoa.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		408DAD04CF7ECEEDE7AED4E4 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Thanks for providing RxAlamofire!

We are using carthage and RxAlamofire in an iOS project and were faced to the following errors when uploading the app to iTunes:

> ERROR ITMS-90205: "Invalid Bundle. The bundle at 'XXX.app/Frameworks/RxAlamofire.framework' contains disallowed nested bundles."
>ERROR ITMS-90206: "Invalid Bundle. The bundle at 'XXX.app/Frameworks/RxAlamofire.framework' contains disallowed file 'Frameworks'."

This errors seem to be caused by the embedded dependencies (Alamofire, RxSwift) which are bundled into `RxAlamofire.framework/Frameworks` by running `carthage copy-frameworks` in a build phase script.

The carthage docs say:

> Nested dependencies
>If the framework you want to add to your project has dependencies explicitly listed in a Cartfile, Carthage will automatically retrieve them for you. You will then have to drag them yourself into your project from the Carthage/Build folder.

[https://github.com/Carthage/Carthage#nested-dependencies](url)

So the nesteded frameworks should not be bundled imho.

I am neither sure whether this is the correct approach nor whether this conflicts with cocoa pods support,  so this PR should serve as a basis to discuss this issue.