### PR TITLE
Fix *rx_progress()* to send *onCompleted()* when *totalBytesWritten* >= *totalBytesExpectedToWrite*

### DIFF
--- a/RxAlamofire/Source/RxAlamofire.swift
+++ b/RxAlamofire/Source/RxAlamofire.swift
@@ -809,11 +809,17 @@ extension Request {
     public func rx_progress() -> Observable<RxProgress> {
         return Observable.create { observer in
             self.progress() { bytesWritten, totalBytesWritten, totalBytesExpectedToWrite in
+
                 observer.onNext(RxProgress(bytesWritten: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite))
+
+                if totalBytesWritten >= totalBytesExpectedToWrite {
+                    observer.onCompleted()
+                }
+
             }
-            
+
             return NopDisposable.instance
-        }
+            }
             // warm up a bit :)
             .startWith(RxProgress(bytesWritten: 0, totalBytesWritten: 0, totalBytesExpectedToWrite: 0))
     }


### PR DESCRIPTION
Hello @bontoJR ,

I have made some changes to rx_progress() to allow signal completion when totalBytesWritten is greater then or equal to totalBytesExpectedToWrite, let me know what do you think.

Have a nice day

Ivan