### PR TITLE
[Hotfix] - Remove embedding frameworks.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
-github "ReactiveX/RxSwift" ~> 2.1 
-github "Alamofire/Alamofire" ~> 3.1
-
+github "ReactiveX/RxSwift" ~> 2.4
+github "Alamofire/Alamofire" ~> 3.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" "3.1.5"
-github "ReactiveX/RxSwift" "2.1.0"
+github "Alamofire/Alamofire" "3.4.0"
+github "ReactiveX/RxSwift" "2.4"

--- a/Podfile
+++ b/Podfile
@@ -3,16 +3,16 @@ source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 def common
-    pod 'Alamofire', '~> 3.1'
-    pod 'RxSwift', '~> 2.1'
-    pod 'RxCocoa', '~> 2.1'
-    pod 'RxBlocking', '~> 2.1'
+    pod 'Alamofire', '~> 3.4'
+    pod 'RxSwift', '~> 2.4'
+    pod 'RxCocoa', '~> 2.4'
+    pod 'RxBlocking', '~> 2.4'
 end
 
 target 'RxAlamofireExample' do
     platform :ios, '8.0'
     common
-    
+
     target 'RxAlamofireTests' do
         pod 'Quick'
         pod 'Nimble'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (3.1.5)
+  - Alamofire (3.4.0)
   - Nimble (3.0.0)
   - OHHTTPStubs (4.7.0):
     - OHHTTPStubs/Default (= 4.7.0)
@@ -15,28 +15,28 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (4.7.0)
   - Quick (0.8.0)
-  - RxBlocking (2.1.0):
-    - RxSwift (~> 2.0)
-  - RxCocoa (2.1.0):
-    - RxSwift (~> 2.0)
-  - RxSwift (2.1.0)
+  - RxBlocking (2.4):
+    - RxSwift (~> 2.4)
+  - RxCocoa (2.4):
+    - RxSwift (~> 2.4)
+  - RxSwift (2.4)
 
 DEPENDENCIES:
-  - Alamofire (~> 3.1)
+  - Alamofire (~> 3.4)
   - Nimble
   - OHHTTPStubs
   - Quick
-  - RxBlocking (~> 2.1)
-  - RxCocoa (~> 2.1)
-  - RxSwift (~> 2.1)
+  - RxBlocking (~> 2.4)
+  - RxCocoa (~> 2.4)
+  - RxSwift (~> 2.4)
 
 SPEC CHECKSUMS:
-  Alamofire: 5f730ba29fd113b7ddd71c1e65d0c630acf5d7b0
+  Alamofire: c19a627cefd6a95f840401c49ab1f124e07f54ee
   Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
   OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  RxBlocking: fa297def258d85c5beae9ed507f94645260b3747
-  RxCocoa: 79b5feb8378545336e756a0a33fcf5e95050b71c
-  RxSwift: 110fb07f81c17c2c3b3254d168363057b1880d18
+  RxBlocking: 1226c1fa0ca1e0ca5f964d4330ca3649f2128680
+  RxCocoa: 7d6cd877de99f5640306b3d6cf87f580c1d91b61
+  RxSwift: 67b9ef4e8b34fb394e200e754c6a09cc16559f94
 
 COCOAPODS: 0.39.0

--- a/RxAlamofire.podspec
+++ b/RxAlamofire.podspec
@@ -17,14 +17,14 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |ss|
     ss.source_files  = "RxAlamofire/Source/*.swift"
-    ss.dependency "RxSwift", "~> 2.1"
-    ss.dependency "Alamofire", "~> 3.1"
+    ss.dependency "RxSwift", "~> 2.4"
+    ss.dependency "Alamofire", "~> 3.4"
     ss.framework  = "Foundation"
   end
 
   s.subspec "RxCocoa" do |ss|
     ss.source_files = "RxAlamofire/Source/Cocoa/*.swift"
-    ss.dependency "RxCocoa", "~> 2.1"
+    ss.dependency "RxCocoa", "~> 2.4"
     ss.dependency "RxAlamofire/Core"
   end
 

--- a/RxAlamofire.xcodeproj/project.pbxproj
+++ b/RxAlamofire.xcodeproj/project.pbxproj
@@ -402,7 +402,6 @@
 				181B4FF31C4D74A8000BA6D6 /* Frameworks */,
 				181B4FF41C4D74A8000BA6D6 /* Headers */,
 				181B4FF51C4D74A8000BA6D6 /* Resources */,
-				181B50011C4D74FC000BA6D6 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -638,22 +637,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxAlamofireExample-RxAlamofireTests/Pods-RxAlamofireExample-RxAlamofireTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		181B50011C4D74FC000BA6D6 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/RxSwift.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/RxCocoa.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		408DAD04CF7ECEEDE7AED4E4 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Description
- @MarianPalkus This is based off #23 but onto develop.
- I've also updated the carthage and CocoaPods dependencies since they were a few minor versions behind.