### PR TITLE
Added method to expose DataResponse - `RxAlamofire.request(...).responseJSON()`.

### DIFF
--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -739,6 +739,12 @@ extension Reactive where Base: SessionManager {
 
 // MARK: Request - Common Response Handlers
 
+extension ObservableType where E == DataRequest {
+    public func responseJSON() -> Observable<DataResponse<Any>> {
+        return self.flatMap { $0.rx.responseJSON() }
+    }
+}
+
 extension Request: ReactiveCompatible {
 }
 
@@ -780,6 +786,25 @@ extension Reactive where Base: DataRequest {
             }
             return Disposables.create {
                 dataRequest.cancel()
+            }
+        }
+    }
+
+    public func responseJSON() -> Observable<DataResponse<Any>> {
+        return Observable.create { observer in
+            let request = self.base
+
+            request.responseJSON { response in
+                if let error = response.result.error {
+                    observer.onError(error)
+                } else {
+                    observer.onNext(response)
+                    observer.onCompleted()
+                }
+            }
+
+            return Disposables.create {
+                request.cancel()
             }
         }
     }


### PR DESCRIPTION
This PR aims to resolve issue https://github.com/RxSwiftCommunity/RxAlamofire/issues/76 

This PR allows using the following syntax to access the underlying `DataResponse` object of a request: 

```swift
RxAlamofire
    .request(.get, "https://jsonplaceholder.typicode.com/posts/1") // Returns Observable<DataRequest>
    .responseJSON() // Returns Observable<DataResponse<Any>>
    .subscribe(onNext: { response in
        print(String(describing: response.result.value))
        print(response.timeline)
    })
    .addDisposableTo(disposeBag)
```