### PR TITLE
allow extension safe api only

### DIFF
--- a/_.xcodeproj/project.pbxproj
+++ b/_.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 		C88CB75F1D8F300C0021D83F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = ZCDS333JM5;
@@ -432,6 +433,7 @@
 		C88CB7601D8F300C0021D83F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = ZCDS333JM5;
@@ -456,6 +458,7 @@
 		C88CB76C1D8F30330021D83F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = ZCDS333JM5;
@@ -483,6 +486,7 @@
 		C88CB76D1D8F30330021D83F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = ZCDS333JM5;


### PR DESCRIPTION
Checked this to allow use in iOS app extensions without a build warning.