### PR TITLE
Provide helper methods for validations and common response types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to this project will be documented in this file.
 * Convert `RxProgress.bytesRemaining` from a stored- to a computed-property.
 * Convert `RxProgress.floatValue` from a function to a computed-property.
 * Add `Equatable` conformation to `RxProgress`.
-* Add Swift Package Manager support
+* Add Swift Package Manager support.
+* Add helper methods for validation to `Observable<DataRequest>`.
+* Add helper methods for common responses to `Observable<DataRequest>`.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 * Add `Equatable` conformation to `RxProgress`.
 * Add Swift Package Manager support.
 * Add helper methods for validation to `Observable<DataRequest>`.
-* Add helper methods for common responses to `Observable<DataRequest>`.
+* Add helper methods for common response types to `Observable<DataRequest>`.
 
 #### Fixed
 

--- a/README.md
+++ b/README.md
@@ -122,19 +122,19 @@ _ = manager.rx.responseString(.get, stringURL)
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }
 
-// URLHTTPResponse + Validation + String
+// URLHTTPResponse + Validation + JSON
 _ = manager.rx.request(.get, stringURL)
     .validate(statusCode: 200 ..< 300)
     .validate(contentType: ["text/json"])
-    .string()
+    .json()
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }
 
-// URLHTTPResponse + Validation + URLHTTPResponse + String
+// URLHTTPResponse + Validation + URLHTTPResponse + JSON
 _ = manager.rx.request(.get, stringURL)
     .validate(statusCode: 200 ..< 300)
     .validate(contentType: ["text/json"])
-    .responseString()
+    .responseJSON()
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }
 

--- a/README.md
+++ b/README.md
@@ -76,17 +76,13 @@ _ = request(.get, stringURL)
 
 // progress
 _ = request(.get, stringURL)
-    .flatMap {
-        $0.rx.progress()
-    }
+    .progress()
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }
 
 // just fire upload and display progress
 _ = upload(Data(), urlRequest: try! RxAlamofire.urlRequest(.get, stringURL))
-    .flatMap {
-        $0.rx.progress()
-    }
+    .progress()
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }
 
@@ -130,9 +126,7 @@ _ = manager.rx.responseString(.get, stringURL)
 _ = manager.rx.request(.get, stringURL)
     .validate(statusCode: 200 ..< 300)
     .validate(contentType: ["text/json"])
-    .flatMap {
-        $0.rx.string()
-    }
+    .string()
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }
 
@@ -140,9 +134,7 @@ _ = manager.rx.request(.get, stringURL)
 _ = manager.rx.request(.get, stringURL)
     .validate(statusCode: 200 ..< 300)
     .validate(contentType: ["text/json"])
-    .flatMap {
-        $0.rx.responseString()
-    }
+    .responseString()
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }
 

--- a/RxAlamofire/RxAlamofire.xcodeproj/project.pbxproj
+++ b/RxAlamofire/RxAlamofire.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03A270B6202B5DF100C3BE0C /* ValidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A270B5202B5DF100C3BE0C /* ValidateTests.swift */; };
 		3BBE9600C2797D13027DDAD9 /* Pods_RxAlamofireTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B537E5740797F3F40C8B8C6 /* Pods_RxAlamofireTests.framework */; };
 		637D95951C4E37CE00F1FA67 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		637D95961C4E37CE00F1FA67 /* (null) in Resources */ = {isa = PBXBuildFile; };
@@ -100,6 +101,7 @@
 
 /* Begin PBXFileReference section */
 		00567E9EC306810E213E955E /* Pods-RxAlamofireTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxAlamofireTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RxAlamofireTests/Pods-RxAlamofireTests.release.xcconfig"; sourceTree = "<group>"; };
+		03A270B5202B5DF100C3BE0C /* ValidateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateTests.swift; sourceTree = "<group>"; };
 		0ACC0B307237D8BCEA10BB35 /* Pods-RxAlamofireExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxAlamofireExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-RxAlamofireExample/Pods-RxAlamofireExample.release.xcconfig"; sourceTree = "<group>"; };
 		1A68A976262D78C5745424C3 /* Pods_RxAlamofire_iOS_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RxAlamofire_iOS_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B537E5740797F3F40C8B8C6 /* Pods_RxAlamofireTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RxAlamofireTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -248,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				A57A28CD1D78E8EB000D88BA /* RxAlamofireTests.swift */,
+				03A270B5202B5DF100C3BE0C /* ValidateTests.swift */,
 				A57A28CF1D78E8EB000D88BA /* Info.plist */,
 			);
 			path = RxAlamofireTests;
@@ -866,6 +869,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A57A28CE1D78E8EB000D88BA /* RxAlamofireTests.swift in Sources */,
+				03A270B6202B5DF100C3BE0C /* ValidateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxAlamofire/RxAlamofireTests/ValidateTests.swift
+++ b/RxAlamofire/RxAlamofireTests/ValidateTests.swift
@@ -1,0 +1,123 @@
+//
+//  ValidateTests.swift
+//  ValidateTests
+//
+//  Created by Nicolas Verinaud on 07/02/18.
+//  Copyright © 2018 Ryfacto. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxCocoa
+import RxBlocking
+import Alamofire
+import OHHTTPStubs
+import RxAlamofire
+
+@testable import Alamofire
+
+class ValidateSpec: XCTestCase {
+    
+    private struct Dummy {
+        static let DataJSONContent = "{\"hello\":\"world\", \"foo\":\"bar\", \"zero\": 0}"
+        static let DataJSON = DataJSONContent.data(using: String.Encoding.utf8)!
+    }
+    
+    var manager: SessionManager!
+    let disposeBag = DisposeBag()
+    
+    override func setUp() {
+        super.setUp()
+        manager = SessionManager()
+        
+        _ = stub(condition: isHost("200.xyz")) { _ in
+            return OHHTTPStubsResponse(data: Dummy.DataJSON, statusCode: 200, headers: ["Content-Type":"application/json"])
+        }
+        
+        _ = stub(condition: isHost("401.xyz")) { _ in
+            return OHHTTPStubsResponse(data: Dummy.DataJSON, statusCode: 401, headers: ["Content-Type":"text/xml"])
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        OHHTTPStubs.removeAllStubs()
+    }
+    
+    func testShouldThrowWhenValidateFails() {
+        do {
+            _ = try request(.get, "http://401.xyz").validate().responseJSON().toBlocking().first()!
+            XCTFail("Should throw")
+        } catch {
+        }
+    }
+    
+    func testShouldNotThrowWhenValidateSucceeds() {
+        do {
+            _ = try request(.get, "http://200.xyz").validate().responseJSON().toBlocking().first()!
+        } catch {
+            XCTFail("Should not throw, but did with \(error)")
+        }
+    }
+    
+    func testShouldThrowWhenValidateStatusCodeFails() {
+        do {
+            _ = try request(.get, "http://401.xyz").validate(statusCode: 200..<300).responseJSON().toBlocking().first()!
+            XCTFail("Should throw when status code is invalid")
+        } catch {
+        }
+    }
+    
+    func testShouldNotThrowWhenValidateStatusCodeSucceeds() {
+        do {
+            _ = try request(.get, "http://200.xyz").validate(statusCode: 200..<300).responseJSON().toBlocking().first()!
+        } catch {
+            XCTFail("Should not throw when status code is valid, but did with \(error)")
+        }
+    }
+    
+    func testShouldThrowWhenValidateContentTypeFails() {
+        do {
+            _ = try request(.get, "http://401.xyz").validate(contentType: [ "application/json" ]).responseJSON().toBlocking().first()!
+            XCTFail("Should throw when content type is invalid")
+        } catch {
+        }
+    }
+    
+    func testShouldNotThrowWhenValidateContentTypeSucceeds() {
+        do {
+            _ = try request(.get, "http://200.xyz").validate(contentType: [ "application/json" ]).responseJSON().toBlocking().first()!
+        } catch {
+            XCTFail("Should not throw when content type is valid, but did with \(error)")
+        }
+    }
+    
+    func testShouldThrowWhenValidateWithCustomValidationFails() {
+        do {
+            _ = try request(.get, "http://401.xyz").validate({ (_, res, _) in
+                return self.validateResponseIs200(res)
+            }).responseJSON().toBlocking().first()!
+            XCTFail("Should throw when validation fails")
+        } catch {
+        }
+    }
+    
+    func testShouldNotThrowWhenValidateWithCustomValidationSucceeds() {
+        do {
+            _ = try request(.get, "http://200.xyz").validate({ (_, res, _) in
+                return self.validateResponseIs200(res)
+            }).responseJSON().toBlocking().first()!
+        } catch {
+            XCTFail("Should not throw when validation succeeds, but did with \(error)")
+        }
+    }
+    
+    private func validateResponseIs200(_ response: HTTPURLResponse) -> Request.ValidationResult {
+        if response.statusCode == 200 {
+            return .success
+        }
+        
+        return .failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: response.statusCode)))
+    }
+}
+

--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -743,6 +743,22 @@ extension ObservableType where E == DataRequest {
     public func responseJSON() -> Observable<DataResponse<Any>> {
         return self.flatMap { $0.rx.responseJSON() }
     }
+    
+    public func validate<S: Sequence>(statusCode: S) -> Observable<DataRequest> where S.Element == Int {
+        return self.map { $0.validate(statusCode: statusCode) }
+    }
+    
+    public func validate() -> Observable<DataRequest> {
+        return self.map { $0.validate() }
+    }
+    
+    public func validate<S: Sequence>(contentType acceptableContentTypes: S) -> Observable<DataRequest> where S.Iterator.Element == String {
+        return self.map { $0.validate(contentType: acceptableContentTypes) }
+    }
+    
+    public func validate(_ validation: @escaping DataRequest.Validation) -> Observable<DataRequest> {
+        return self.map { $0.validate(validation) }
+    }
 }
 
 extension Request: ReactiveCompatible {

--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -744,6 +744,42 @@ extension ObservableType where E == DataRequest {
         return self.flatMap { $0.rx.responseJSON() }
     }
     
+    public func json(options: JSONSerialization.ReadingOptions = .allowFragments) -> Observable<Any> {
+        return self.flatMap { $0.rx.json(options: options) }
+    }
+    
+    public func responseString(encoding: String.Encoding? = nil) -> Observable<(HTTPURLResponse, String)> {
+        return self.flatMap { $0.rx.responseString(encoding: encoding) }
+    }
+    
+    public func string(encoding: String.Encoding? = nil) -> Observable<String> {
+        return self.flatMap { $0.rx.string(encoding: encoding) }
+    }
+    
+    public func responseData() -> Observable<(HTTPURLResponse, Data)> {
+        return self.flatMap { $0.rx.responseData() }
+    }
+    
+    public func data() -> Observable<Data> {
+        return self.flatMap { $0.rx.data() }
+    }
+    
+    public func responsePropertyList(options: PropertyListSerialization.ReadOptions = PropertyListSerialization.ReadOptions()) -> Observable<(HTTPURLResponse, Any)> {
+        return self.flatMap { $0.rx.responsePropertyList(options: options) }
+    }
+    
+    public func propertyList(options: PropertyListSerialization.ReadOptions = PropertyListSerialization.ReadOptions()) -> Observable<Any> {
+        return self.flatMap { $0.rx.propertyList(options: options) }
+    }
+    
+    public func progress() -> Observable<RxProgress> {
+        return self.flatMap { $0.rx.progress() }
+    }
+}
+
+// MARK: Request - Validation
+
+extension ObservableType where E == DataRequest {
     public func validate<S: Sequence>(statusCode: S) -> Observable<E> where S.Element == Int {
         return self.map { $0.validate(statusCode: statusCode) }
     }

--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -744,19 +744,19 @@ extension ObservableType where E == DataRequest {
         return self.flatMap { $0.rx.responseJSON() }
     }
     
-    public func validate<S: Sequence>(statusCode: S) -> Observable<DataRequest> where S.Element == Int {
+    public func validate<S: Sequence>(statusCode: S) -> Observable<E> where S.Element == Int {
         return self.map { $0.validate(statusCode: statusCode) }
     }
     
-    public func validate() -> Observable<DataRequest> {
+    public func validate() -> Observable<E> {
         return self.map { $0.validate() }
     }
     
-    public func validate<S: Sequence>(contentType acceptableContentTypes: S) -> Observable<DataRequest> where S.Iterator.Element == String {
+    public func validate<S: Sequence>(contentType acceptableContentTypes: S) -> Observable<E> where S.Iterator.Element == String {
         return self.map { $0.validate(contentType: acceptableContentTypes) }
     }
     
-    public func validate(_ validation: @escaping DataRequest.Validation) -> Observable<DataRequest> {
+    public func validate(_ validation: @escaping DataRequest.Validation) -> Observable<E> {
         return self.map { $0.validate(validation) }
     }
 }

--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -741,39 +741,39 @@ extension Reactive where Base: SessionManager {
 
 extension ObservableType where E == DataRequest {
     public func responseJSON() -> Observable<DataResponse<Any>> {
-        return self.flatMap { $0.rx.responseJSON() }
+        return flatMap { $0.rx.responseJSON() }
     }
     
     public func json(options: JSONSerialization.ReadingOptions = .allowFragments) -> Observable<Any> {
-        return self.flatMap { $0.rx.json(options: options) }
+        return flatMap { $0.rx.json(options: options) }
     }
     
     public func responseString(encoding: String.Encoding? = nil) -> Observable<(HTTPURLResponse, String)> {
-        return self.flatMap { $0.rx.responseString(encoding: encoding) }
+        return flatMap { $0.rx.responseString(encoding: encoding) }
     }
     
     public func string(encoding: String.Encoding? = nil) -> Observable<String> {
-        return self.flatMap { $0.rx.string(encoding: encoding) }
+        return flatMap { $0.rx.string(encoding: encoding) }
     }
     
     public func responseData() -> Observable<(HTTPURLResponse, Data)> {
-        return self.flatMap { $0.rx.responseData() }
+        return flatMap { $0.rx.responseData() }
     }
     
     public func data() -> Observable<Data> {
-        return self.flatMap { $0.rx.data() }
+        return flatMap { $0.rx.data() }
     }
     
     public func responsePropertyList(options: PropertyListSerialization.ReadOptions = PropertyListSerialization.ReadOptions()) -> Observable<(HTTPURLResponse, Any)> {
-        return self.flatMap { $0.rx.responsePropertyList(options: options) }
+        return flatMap { $0.rx.responsePropertyList(options: options) }
     }
     
     public func propertyList(options: PropertyListSerialization.ReadOptions = PropertyListSerialization.ReadOptions()) -> Observable<Any> {
-        return self.flatMap { $0.rx.propertyList(options: options) }
+        return flatMap { $0.rx.propertyList(options: options) }
     }
     
     public func progress() -> Observable<RxProgress> {
-        return self.flatMap { $0.rx.progress() }
+        return flatMap { $0.rx.progress() }
     }
 }
 
@@ -781,19 +781,19 @@ extension ObservableType where E == DataRequest {
 
 extension ObservableType where E == DataRequest {
     public func validate<S: Sequence>(statusCode: S) -> Observable<E> where S.Element == Int {
-        return self.map { $0.validate(statusCode: statusCode) }
+        return map { $0.validate(statusCode: statusCode) }
     }
     
     public func validate() -> Observable<E> {
-        return self.map { $0.validate() }
+        return map { $0.validate() }
     }
     
     public func validate<S: Sequence>(contentType acceptableContentTypes: S) -> Observable<E> where S.Iterator.Element == String {
-        return self.map { $0.validate(contentType: acceptableContentTypes) }
+        return map { $0.validate(contentType: acceptableContentTypes) }
     }
     
     public func validate(_ validation: @escaping DataRequest.Validation) -> Observable<E> {
-        return self.map { $0.validate(validation) }
+        return map { $0.validate(validation) }
     }
 }
 


### PR DESCRIPTION
I just tried to validate responses and I found it hard to use `flatMap`.

Here is what it looked like in the doc :

```
_ = request(.get, stringURL)
    .flatMap { request in
        return request.validate(statusCode: 200..<300)
        .validate(contentType: ["text/json"])
            .rx.json()
    }
    .observeOn(MainScheduler.instance)
    .subscribe { print($0) }
```

And with the improvement :

```
_ = request(.get, stringURL)
    .validate(statusCode: 200..<300)
    .validate(contentType: ["application/json"])
    .responseJSON()
    .observeOn(MainScheduler.instance)
    .subscribe { print($0) }
```

Moreover, I find it easier to discover how to do validation this way using autocompletion.

So I created some nice wrappers around `DataRequest.validate` by extending `Observable<DataRequest>`.

Let me know what you think. 😉