### PR TITLE
Fix SPM paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,6 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 
+* Fix SPM Support
 * Unify download and upload progress handling.
 * Fix `Reactive<DataRequest>.progress` logic so it actually completes.

--- a/Package.swift
+++ b/Package.swift
@@ -26,10 +26,6 @@ let package = Package(
             name: "RxAlamofire",
             dependencies: ["RxSwift", "Alamofire"],
             path: "Sources",
-            exclude: ["Cocoa"]),
-        .testTarget(
-            name: "RxAlamofireTests",
-            dependencies: ["RxAlamofire", "RxSwift", "Alamofire"],
-            path: "RxAlamofire/RxAlamofireTests"),
+            exclude: ["Cocoa"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,9 +24,12 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "RxAlamofire",
-            dependencies: ["RxSwift", "Alamofire"]),
+            dependencies: ["RxSwift", "Alamofire"],
+            path: "Sources",
+            exclude: ["Cocoa"]),
         .testTarget(
             name: "RxAlamofireTests",
-            dependencies: ["RxAlamofire", "RxSwift", "Alamofire"]),
+            dependencies: ["RxAlamofire", "RxSwift", "Alamofire"],
+            path: "RxAlamofire/RxAlamofireTests"),
     ]
 )


### PR DESCRIPTION
Trying to depend on RxAlamofire was failing because paths are funky this specifies the right directory so that other packages can depend on this library