### PR TITLE
Add RX extension for encoding multipart form data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 #### Updated
+* Add `Reactive<SessionManager>.upload(multipartFormData:to:)`
 
 #### Fixed
 

--- a/RxAlamofire/RxAlamofireTests/RxAlamofireTests.swift
+++ b/RxAlamofire/RxAlamofireTests/RxAlamofireTests.swift
@@ -72,6 +72,20 @@ class RxAlamofireSpec: XCTestCase {
         }
 	}
 
+    func testMultipartFormDataEncoding() {
+        do {
+            let request = try manager.rx.upload(multipartFormData: { mfd in
+                mfd.append("bar".data(using: .utf8)!, withName: "foo")
+                mfd.append("qux".data(using: .utf8)!, withName: "baz")
+            }, to: "http://myjsondata.com").toBlocking().single()
+
+            XCTAssertEqual("http://myjsondata.com", request.request?.url?.absoluteString)
+            XCTAssertEqual(HTTPMethod.post.rawValue, request.request?.httpMethod)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
     func testProgress() {
         do {
             let dataRequest = try request(HTTPMethod.get, "http://myjsondata.com").toBlocking().first()!

--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -704,6 +704,58 @@ extension Reactive where Base: SessionManager {
         }
     }
 
+    // MARK: Multipart upload
+
+    /**
+     Returns an observable of an `UploadRequest` using the `url`, `method` and `headers`,
+     and a body that contains `multipart/form-data` content encoded from the input data,
+     provided by the `multipartFormData` parameter.
+
+     It is important to understand the memory implications of uploading `MultipartFormData`. If the cummulative
+     payload is small, encoding the data in-memory and directly uploading to a server is the by far the most
+     efficient approach. However, if the payload is too large, encoding the data in-memory could cause your app to
+     be terminated. Larger payloads must first be written to disk using input and output streams to keep the memory
+     footprint low, then the data can be uploaded as a stream from the resulting file. Streaming from disk MUST be
+     used for larger payloads such as video content.
+
+     The `encodingMemoryThreshold` parameter allows Alamofire to automatically determine whether to encode in-memory
+     or stream from disk. If the content length of the `MultipartFormData` is below the `encodingMemoryThreshold`,
+     encoding takes place in-memory. If the content length exceeds the threshold, the data is streamed to disk
+     during the encoding process. Then the result is uploaded as data or as a stream depending on which encoding
+     technique was used.
+
+     - parameter multipartFormData:       The closure used to append body parts to the `MultipartFormData`.
+     - parameter encodingMemoryThreshold: The encoding memory threshold in bytes.
+                                          `multipartFormDataEncodingMemoryThreshold` by default.
+     - parameter url:                     The URL.
+     - parameter method:                  The HTTP method. `.post` by default.
+     - parameter headers:                 The HTTP headers. `nil` by default.
+    */
+    public func upload(multipartFormData data: @escaping (MultipartFormData) -> Void,
+                       usingThreshold encodingMemoryThreshold: UInt64 = SessionManager.multipartFormDataEncodingMemoryThreshold,
+                       to url: URLConvertible,
+                       method: HTTPMethod = .post,
+                       headers: HTTPHeaders = [:]) -> Observable<UploadRequest> {
+        let manager = base
+        return Observable.create { observer in
+            manager.upload(multipartFormData: data,
+                           usingThreshold: encodingMemoryThreshold,
+                           to: url,
+                           method: method,
+                           headers: headers) {
+                switch $0 {
+                case .failure(let error):
+                    observer.onError(error)
+                case .success(let request, _, _):
+                    observer.onNext(request)
+                    observer.onCompleted()
+                }
+            }
+
+            return Disposables.create()
+        }
+    }
+
     // MARK: Download
 
     /**


### PR DESCRIPTION
Fixes #84 (should be squashed).

Example usage:

```
func testMultipartFormData() -> Observable<String> {
    let request = manager.rx.upload(multipartFormData: { multipartFormData in
        multipartFormData.append("foo".data(using: .utf8)!, withName: "bar")
        multipartFormData.append("baz".data(using: .utf8)!, withName: "qux")
    }, to: "https://httpbin.org/post")

    return request.flatMap { $0.rx.responseString() }
}
```

---

Unfortunately, I haven't found a way to test if the _encoding itself_ is correct or not – at least not in a way that works without any external services, like httpbin.org.

It may not even be the responsibility of this project to do so.