### PR TITLE
Add a method to return DataResponse from DataRequest.responseString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 #### Updated
+* Add a new method DataRequest.dataResponseString() which returns a
+  DataResponse. This allows access to performance metrics.
 
 #### Fixed
 

--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -693,6 +693,10 @@ extension ObservableType where Element == DataRequest {
     return flatMap { $0.rx.json(options: options) }
   }
 
+  public func dataResponseString(encoding: String.Encoding? = nil) -> Observable<DataResponse<String>> {
+      return flatMap { $0.rx.dataResponseString(encoding: encoding) }
+  }
+    
   public func responseString(encoding: String.Encoding? = nil) -> Observable<(HTTPURLResponse, String)> {
     return flatMap { $0.rx.responseString(encoding: encoding) }
   }
@@ -848,6 +852,34 @@ extension Reactive where Base: DataRequest {
     return result(responseSerializer: DataRequest.dataResponseSerializer())
   }
 
+    /**
+     Returns an `Observable` of a `DataResponse<String>` for the current request.
+     `DataResponse` allows access to the unprocessed server response, including **metrics**.
+     
+     - parameter encoding: Type of the string encoding, **default:** `nil`
+     
+     - returns: An instance of `Observable<DataResponse<String>`
+     */
+    public func dataResponseString(encoding: String.Encoding? = nil) -> Observable<DataResponse<String>> {
+        return Observable.create { observer in
+            let request = self.base
+            
+            request.responseString(encoding: encoding) { response in
+                if let error = response.result.error {
+                    observer.on(.error(error))
+                } else {
+                    observer.on(.next(response))
+                    observer.on(.completed)
+                }
+            }
+            
+            return Disposables.create {
+                request.cancel()
+            }
+        }
+        
+    }
+    
   /**
    Returns an `Observable` of a String for the current request
 


### PR DESCRIPTION
This is similar to PR #79 except for `responseString()` instead of `responseJSON()`. I wrote it to work identically to the code in that pull request.

It allows access to metrics (NSURLSessionTaskMetrics mentioned in issue #76 ) for those who need the response as a string, not JSON.