### PR TITLE
Fix exchange rate api error in example project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 
+* Fixed exchange rate api error in example project
+
 ## 5.0.0
 
 #### Updated


### PR DESCRIPTION
The [old](api.fixer.io) exchange rate api is deprecated, this pr changed it to https://exchangeratesapi.io/. 