### PR TITLE
Add response methods for `Observable<DownloadRequest>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 #### Updated
 
+* Add response methods for `Observable<DownloadRequest>`.
+
 #### Fixed
 
 ## 5.0.0

--- a/RxAlamofireTests/RxAlamofireTests.swift
+++ b/RxAlamofireTests/RxAlamofireTests.swift
@@ -110,7 +110,7 @@ class RxAlamofireSpec: XCTestCase {
         XCTAssertNotEqual(subject, different)
     }
     
-    func testDownload() {
+    func testDownloadResponse() {
         do {
             let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             let fileURL = temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")
@@ -128,21 +128,35 @@ class RxAlamofireSpec: XCTestCase {
             
             XCTAssertEqual(defaultResponse.response?.statusCode, 200)
             XCTAssertNotNil(defaultResponse.destinationURL)
-            
-            let jsonResponse = try request.rx
-                .responseSerialized(responseSerializer: DownloadRequest.jsonResponseSerializer())
-                .toBlocking()
-                .first()!
-            XCTAssertEqual(jsonResponse.response?.statusCode, 200)
-            guard let json = jsonResponse.value as? [String: Any] else {
-                XCTFail("Bad Response")
-                return
-            }
-            
-            XCTAssertEqual(json["hello"] as? String, "world")
         } catch {
             XCTFail("\(error)")
         }
     }
 
+    func testDownloadResponseSerialized() {
+        do {
+            let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            let fileURL = temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")
+            
+            let destination: DownloadRequest.DownloadFileDestination = { _, _ in (fileURL, []) }
+            let request = download(
+                "http://myjsondata.com",
+                to: destination
+            )
+            
+            let jsonResponse = try request.rx
+                .responseSerialized(responseSerializer: DownloadRequest.jsonResponseSerializer())
+                .toBlocking()
+                .first()!
+            
+            XCTAssertEqual(jsonResponse.response?.statusCode, 200)
+            guard let json = jsonResponse.value as? [String: Any] else {
+                XCTFail("Bad Response")
+                return
+            }
+            XCTAssertEqual(json["hello"] as? String, "world")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }

--- a/Sources/RxAlamofire.swift
+++ b/Sources/RxAlamofire.swift
@@ -724,27 +724,28 @@ extension ObservableType where Element == DataRequest {
 
 extension ObservableType where Element: DownloadRequest {
     
-    public func response() -> Observable<DefaultDownloadResponse> {
-        return flatMap { $0.rx.response() }
-    }
+  public func response() -> Observable<DefaultDownloadResponse> {
+    return flatMap { $0.rx.response() }
+  }
     
-    public func responseSerialized<Serializer: DownloadResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
-        responseSerializer: Serializer
-    )
-        -> Observable<DownloadResponse<Serializer.SerializedObject>>
-    {
-        return flatMap { $0.rx.responseSerialized(queue: queue, responseSerializer: responseSerializer) }
-    }
+  public func responseSerialized<Serializer: DownloadResponseSerializerProtocol>(
+    queue: DispatchQueue? = nil,
+    responseSerializer: Serializer
+  )
+    -> Observable<DownloadResponse<Serializer.SerializedObject>>
+  {
+    return flatMap { $0.rx.responseSerialized(queue: queue, responseSerializer: responseSerializer) }
+  }
     
-    public func responseResult<Serializer: DownloadResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
-        responseSerializer: Serializer
-    )
-        -> Observable<Serializer.SerializedObject>
-    {
-        return flatMap { $0.rx.responseResult(queue: queue, responseSerializer: responseSerializer) }
-    }
+  public func responseResult<Serializer: DownloadResponseSerializerProtocol>(
+    queue: DispatchQueue? = nil,
+    responseSerializer: Serializer
+  )
+    -> Observable<Serializer.SerializedObject>
+  {
+    return flatMap { $0.rx.responseResult(queue: queue, responseSerializer: responseSerializer) }
+  }
+
 }
 
 // MARK: Request - Validation
@@ -930,47 +931,47 @@ extension Reactive where Base: DataRequest {
 
 extension Reactive where Base: DownloadRequest {
     
-    public func response() -> Single<DefaultDownloadResponse> {
-        return Single.create { cb in
-            let request = self.base.response(completionHandler: { (response) in
-                cb(.success(response))
-            })
-            return Disposables.create(with: request.cancel)
-        }
+  public func response() -> Single<DefaultDownloadResponse> {
+    return Single.create { cb in
+      let request = self.base.response {
+        cb(.success($0))
+      }
+      return Disposables.create(with: request.cancel)
     }
+  }
     
-    public func responseSerialized<Serializer: DownloadResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
-        responseSerializer: Serializer
-    )
-        -> Single<DownloadResponse<Serializer.SerializedObject>>
-    {
-        return Single.create { cb in
-            let request = self.base.response(
-                queue: queue,
-                responseSerializer: responseSerializer
-            ) { (response) in
-                cb(.success(response))
-            }
-            
-            return Disposables.create(with: request.cancel)
-        }
+  public func responseSerialized<Serializer: DownloadResponseSerializerProtocol>(
+    queue: DispatchQueue? = nil,
+    responseSerializer: Serializer
+  )
+    -> Single<DownloadResponse<Serializer.SerializedObject>>
+  {
+    return Single.create { cb in
+      let request = self.base.response(
+        queue: queue,
+        responseSerializer: responseSerializer
+      ) {
+        cb(.success($0))
+      }
+        
+      return Disposables.create(with: request.cancel)
     }
+  }
     
-    public func responseResult<Serializer: DownloadResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
-        responseSerializer: Serializer
-    )
-        -> Single<Serializer.SerializedObject>
-    {
-        return responseSerialized(queue: queue, responseSerializer: responseSerializer)
-            .flatMap { response -> Single<Serializer.SerializedObject> in
-                switch response.result {
-                case .success(let r):   return .just(r)
-                case .failure(let e):   return .error(e)
-                }
-            }
-    }
+  public func responseResult<Serializer: DownloadResponseSerializerProtocol>(
+    queue: DispatchQueue? = nil,
+    responseSerializer: Serializer
+  )
+    -> Single<Serializer.SerializedObject>
+  {
+    return responseSerialized(queue: queue, responseSerializer: responseSerializer)
+      .flatMap { response -> Single<Serializer.SerializedObject> in
+        switch response.result {
+        case .success(let r):   return .just(r)
+        case .failure(let e):   return .error(e)
+        }
+      }
+  }
 }
 
 extension Reactive where Base: Request {


### PR DESCRIPTION
Using these APIs, we can directly observe the completion of the download.

```swift
request.response()
request.responseSerialized(...)
request.responseResult(...)
```