### PR TITLE
Create Rx extensions mapping to Alamofire response method

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ let stringURL = ""
 let session = URLSession.shared()
 
 _ = session.rx
+    .response(.get, stringURL)
+    .observeOn(MainScheduler.instance)
+    .subscribe { print($0) }
+
+_ = session.rx
     .json(.get, stringURL)
     .observeOn(MainScheduler.instance)
     .subscribe { print($0) }

--- a/Tests/RxAlamofireTests/RxAlamofireTests.swift
+++ b/Tests/RxAlamofireTests/RxAlamofireTests.swift
@@ -59,6 +59,15 @@ class RxAlamofireSpec: XCTestCase {
 
   // MARK: Tests
   func testBasicRequest() {
+      do {
+        let result = try requestResponse(HTTPMethod.get, "http://mywebservice.com").toBlocking().first()!
+        XCTAssertEqual(result.statusCode, 200)
+      } catch {
+        XCTFail("\(error)")
+      }
+  }
+
+  func testStringRequest() {
     do {
       let (result, string) = try requestString(HTTPMethod.get, "http://mywebservice.com").toBlocking().first()!
       XCTAssertEqual(result.statusCode, 200)


### PR DESCRIPTION
**Use Case:**
Imagine an HTTP API which returned status code 200, with an empty body.
Using `responseJSON` or `responseData` produces:

> could not be serialized. Input data was nil or zero length

Just using RxAlamofire's `AF.rx.request(urlRequest: urlRequest).validate()` works, but if the API returns a 500, the validation doesn't actually work because the response is not yet set on the `response` property of the `DataRequest`.

It seems that API's with empty bodies aren't considered bad practice, nor discouraged by the HTTP specification.
https://softwareengineering.stackexchange.com/questions/211275/should-an-http-api-always-return-a-body

**The Change**
Alamofire already has an API which returns just the raw `HTTPURLResponse`, this PR is just creating an Rx mapping for it.