### PR TITLE
#trivial Add custom response serializer for response data

### DIFF
--- a/Sources/RxAlamofire/RxAlamofire.swift
+++ b/Sources/RxAlamofire/RxAlamofire.swift
@@ -1444,8 +1444,8 @@ public extension Reactive where Base: DataRequest {
 
    - returns: An instance of `Observable<NSData>`
    */
-  func responseData() -> Observable<(HTTPURLResponse, Data)> {
-    return responseResult(responseSerializer: DataResponseSerializer())
+    func responseData(dataResponseSerializer: DataResponseSerializer = DataResponseSerializer()) -> Observable<(HTTPURLResponse, Data)> {
+    return responseResult(responseSerializer: dataResponseSerializer)
   }
 
   func data() -> Observable<Data> {


### PR DESCRIPTION
This would provide the option to the user to provide a custom DataResponseSerializer() with minimum effort. Also works as a solution for those who don't want to throw error on a 200 or 202 server response if an empty body is received by easily supplying a custom Response Serializer. 