### PR TITLE
Alamofire 4.9.x with RxSwift 6.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveX/RxSwift" ~> 5.0
-github "Alamofire/Alamofire" ~> 4.8
+github "ReactiveX/RxSwift" ~> 6.0
+github "Alamofire/Alamofire" ~> 4.9

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Alamofire/Alamofire" "4.8.2"
+github "Alamofire/Alamofire" "4.9.1"
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "ReactiveX/RxSwift" "5.0.1"
+github "ReactiveX/RxSwift" "6.2.0"

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
   
   dependencies: [
     // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "4.8.2")),
-    .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.1" ),
+    .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "4.9.1")),
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0" ),
   ],
   
   targets: [

--- a/RxAlamofire.podspec
+++ b/RxAlamofire.podspec
@@ -20,14 +20,14 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |ss|
     ss.source_files = "Sources/*.swift"
-    ss.dependency "RxSwift", "~> 5.0"
-    ss.dependency "Alamofire", "~> 4.8"
+    ss.dependency "RxSwift", "~> 6.0"
+    ss.dependency "Alamofire", "~> 4.9"
     ss.framework = "Foundation"
   end
 
   s.subspec "RxCocoa" do |ss|
     ss.source_files = "Sources/Cocoa/*.swift"
-    ss.dependency "RxCocoa", "~> 5.0"
+    ss.dependency "RxCocoa", "~> 6.0"
     ss.dependency "RxAlamofire/Core"
   end
 end

--- a/RxAlamofire.podspec
+++ b/RxAlamofire.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/RxSwiftCommunity/RxAlamofire.git", :tag => s.version }
   s.swift_version = "5.0"
 
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "10.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "3.0"


### PR DESCRIPTION
Moving to Alamofire 5.x isn't possible for us at the moment but we would like to be one RxSwift 6.2 for other reasons.

This is branched off 5.1.0 tag (the last Alamofire 4.x release as far as I can tell) but github won't accept a pr against it for some reason.

I'll appreciate if this is no longer part of this repo and maintain my own fork until we can get Alamofire upgraded.