### PR TITLE
Use SPM product AlamofireDynamic to resolve a privacy manifest issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(name: "RxAlamofire",
                         .target(name: "RxAlamofire",
                                 dependencies: [
                                   .product(name: "RxSwift", package: "RxSwift"),
-                                  .product(name: "Alamofire", package: "Alamofire"),
+                                  .product(name: "AlamofireDynamic", package: "Alamofire"),
                                   .product(name: "RxCocoa", package: "RxSwift")
                                 ],
                                 path: "Sources"),


### PR DESCRIPTION
Switched the SPM package product to AlamofireDynamic, which is required for apps to inherit the Alamofire privacy manifest

For example, this change will resolve the following email when a project imports `RxAlamofire`.

<img width="400" alt="example-email" src="https://github.com/RxSwiftCommunity/RxAlamofire/assets/52302810/e3b11971-691f-4047-8c31-a8ef1c8a7532">

This change is also available for testing, as an unofficial release under my fork:
https://github.com/fraune/RxAlamofire/releases/tag/v6.1.3